### PR TITLE
Add link to the archived docs site

### DIFF
--- a/src/partials/version.hbs
+++ b/src/partials/version.hbs
@@ -36,6 +36,7 @@
                         <li><a href="https://docs.micrometer.io/micrometer/reference/">Micrometer</a></li>
                         <li><a href="https://docs.micrometer.io/tracing/reference/">Tracing</a></li>
                         <li><a href="https://docs.micrometer.io/micrometer-docs-generator/reference/">Docs Generator</a></li>
+                        <li><a href="https://micrometer.io/docs/">Docs Archive (1.11 and earlier)</a></li>
                       </ul>
                     </li>
                   </ul>


### PR DESCRIPTION
It looks like this:
<img width="1083" alt="Screenshot 2024-02-28 at 10 17 32" src="https://github.com/micrometer-metrics/antora-ui-micrometer/assets/3044070/f9a4f80e-0c8e-41e3-b929-c85597cc659a">
